### PR TITLE
update benchmark command to consume only pieces produced during the run

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Download a binary file from [releases](https://github.com/Cerebellum-Network/ddc
 
 ## Commands
 
+### configure
+
+You can configure ddc-cli (e.g. bootstrapNodes, appPubKey and appPrivKey for data producing/consuming) using next
+command:
+
+```shell script
+ddc-cli configure --bootstrapNodes http://localhost:8080 --appPubKey APP_PUB_KEY --appPrivKey APP_PRIV_KEY
+```
+
 ### create-app
 
 You can create application in DDC using next command (subscription in SC required):
@@ -26,14 +35,6 @@ ddc-cli create-app --appPubKey APP_PUB_KEY --appPrivKey APP_PRIV_KEY
 
 > **_NOTE:_**  Subscription in SC required (except dev environment where SC is mocked). If appPubkey and appPrivKey are not present - new app will be generated (dev only).
 
-### configure
-
-You can configure ddc-cli (e.g. bootstrapNodes, appPubKey and appPrivKey for data producing/consuming) using next
-command:
-
-```shell script
-ddc-cli configure --bootstrapNodes http://localhost:8080 --appPubKey APP_PUB_KEY --appPrivKey APP_PRIV_KEY
-```
 
 ### produce
 

--- a/src/main/kotlin/network/cere/ddc/cli/picocli/BenchmarkCommand.kt
+++ b/src/main/kotlin/network/cere/ddc/cli/picocli/BenchmarkCommand.kt
@@ -48,8 +48,10 @@ class BenchmarkCommand(private val ddcCliConfigFile: DdcCliConfigFile) : Abstrac
 
     override fun run() {
         val configOptions = ddcCliConfigFile.read(profile)
+        val producingStartTime = Instant.now().toString()
         produce(configOptions)
-        consume(configOptions)
+        val producingEndTime = Instant.now().toString()
+        consume(configOptions, producingStartTime, producingEndTime)
     }
 
     private fun produce(configOptions: Map<String, String>) {
@@ -103,14 +105,14 @@ class BenchmarkCommand(private val ddcCliConfigFile: DdcCliConfigFile) : Abstrac
         println("WCU/sec: ${totalWcu.get() / durationInSec}")
     }
 
-    private fun consume(configOptions: Map<String, String>) {
+    private fun consume(configOptions: Map<String, String>, startTime: String, endTime: String) {
         val ddcConsumer = buildConsumer(configOptions)
 
         val totalBytes = AtomicLong(0)
         val totalRcu = AtomicLong(0)
         val consumingStart = System.currentTimeMillis()
 
-        ddcConsumer.getAppPieces().subscribe().asStream().forEach { p ->
+        ddcConsumer.getAppPieces(startTime, endTime).subscribe().asStream().forEach { p ->
             totalBytes.addAndGet(getSize(p).toLong())
         }
 


### PR DESCRIPTION
resolves https://cerenetwork.atlassian.net/browse/CBI-1350

some sample runs:

============================================================
Producing
Total requests: 663
Total WCU: 33801
Req/sec: 11
WCU/sec: 563
============================================================
Consuming
Total bytes: 138363955
Total RCU: 33781
RCU/sec: 16890



============================================================
Producing
Total requests: 323
Total WCU: 16004
Req/sec: 5
WCU/sec: 266
============================================================
Consuming
Total bytes: 65886959
Total RCU: 16086
RCU/sec: 16086