### PR TITLE
fix ClassNotFoundException with native-image app

### DIFF
--- a/src/main/resources/reflection-config.json
+++ b/src/main/resources/reflection-config.json
@@ -18,5 +18,17 @@
   },
   {
     "name": "kotlin.KotlinVersion$Companion[]"
+  },
+  {
+    "name": "org.kethereum.crypto.impl.kdf.PBKDF2Impl",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "org.kethereum.crypto.impl.mac.HmacImpl",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "org.kethereum.crypto.impl.ec.EllipticCurveSigner",
+    "allDeclaredConstructors": true
   }
 ]


### PR DESCRIPTION
native-image does not support reflection but CryptoAPI (from kethereum) requires reflection: this fix adds reflection support for the required classes only and if later we start using additional ones loaded through reflection, we will need to add them to the configuration again.